### PR TITLE
Add Birdwatcher

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1672,6 +1672,11 @@
                "name": "Tweet Metadata",
                "type": "url",
                "url": "http://online.wsj.com/public/resources/documents/TweetMetadata.pdf"
+            }, {
+               "id": "1086",
+               "name": "Birdwatcher (T)",
+               "type": "url",
+               "url": "https://github.com/michenriksen/birdwatcher"
             }],
             "id": "814",
             "name": "Analytics",


### PR DESCRIPTION
Hey there,

This adds my newly released Twitter OSINT tool [Birdwatcher](http://michenriksen.com/blog/birdwatcher-twitter-osint-framework/) under `Social Networks` -> `Twitter` -> `Analytics`.

I gave the new node the highest unused ID; I hope that is the correct way to do it.

Thanks for an awesome resource!