### PR TITLE
Add StackShare under Domain Name > Analytics

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -591,6 +591,11 @@
             "name": "Keyword Density",
             "type": "url",
             "url": "http://tools.seobook.com/general/keyword-density/"
+         }, {
+            "id": "1444",
+            "name": "StackShare",
+            "type": "url",
+            "url": "https://stackshare.io/"
          }],
          "id": "617",
          "name": "Analytics",


### PR DESCRIPTION
This adds a link to [StackShare](https://stackshare.io/) which I think is a pretty nifty resource for finding out what technologies and tools an organization is using. Here's some example reports:

* [Airbnb](https://stackshare.io/airbnb/airbnb)
* [Spotify](https://stackshare.io/spotify/spotify)
* [GitHub](https://stackshare.io/github/github)
