### PR TITLE
Added trape (T) to People Search Engines

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -3519,6 +3519,12 @@
           "name": "True People Search",
           "type": "url",
           "url": "https://www.truepeoplesearch.com/"
+        },
+        {
+          "id": "1291",
+          "name": "trape (T)",
+          "type": "url",
+          "url": "https://github.com/boxug/trape"
         }
       ],
       "id": "471",


### PR DESCRIPTION
trape - People tracker on the Internet _("Learn to track the world, to avoid being traced.")_