### PR TITLE
Added Onion Investigator to Darkweb - Discovery

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -6354,6 +6354,12 @@
               "name": "docker-onion-nmap (T)",
               "type": "url",
               "url": "https://github.com/milesrichardson/docker-onion-nmap"
+            },
+            {
+              "id": "1291",
+              "name": "Onion Investigator",
+              "type": "url",
+              "url": "https://oint.ctrlbox.com/"
             }
           ],
           "id": "894",


### PR DESCRIPTION
Onion Investigator "This site was created out of curisoty, how easy would it be to create a shodan like website and service for .onions, turns out it is pretty easy."