### PR TITLE
Update arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -4118,7 +4118,14 @@
               "name": "Gov Data Canada",
               "type": "url",
               "url": "https://govdataca.com/"
+            },
+            {
+              "id": "1346",
+              "name": "CA Salary DB",
+              "type": "url",
+              "url": "http://www.sacbee.com/site-services/databases/state-pay/article2642161.html"
             }
+            
           ],
           "id": "1107",
           "name": "Government Records",
@@ -8265,5 +8272,5 @@
   "id": "1",
   "name": "OSINT Framework",
   "type": "folder",
-  "desc": "Next Available ID: 1346"
+  "desc": "Next Available ID: 1347"
 }


### PR DESCRIPTION
Added California state employee salary database updated by the Sacramento Bee as ID 1346.  Public Records > Government Records 

Updated next available ID from 1346 to 1347.