### PR TITLE
Fix GlobalFileSearch link

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -5393,7 +5393,7 @@
               "id": "731",
               "name": "GlobalFile",
               "type": "url",
-              "url": "http://globalfilesearch.net/index.aspx"
+              "url": "https://globalfilesearch.com/"
             },
             {
               "id": "732",


### PR DESCRIPTION
GlobalFileSearch.net does not exist.

GlobalFileSearch.com does exist.