### PR TITLE
Remove Google+

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -2596,27 +2596,6 @@
         {
           "children": [
             {
-              "name": "Google+",
-              "type": "url",
-              "url": "https://plus.google.com/"
-            },
-            {
-              "name": "Google+ Profiles (M)",
-              "type": "url",
-              "url": "https://plus.google.com/+Username/posts"
-            },
-            {
-              "name": "Google Plus Search",
-              "type": "url",
-              "url": "http://googleplussearch.chromefans.org/"
-            }
-          ],
-          "name": "Google+",
-          "type": "folder"
-        },
-        {
-          "children": [
-            {
               "name": "SnoopSnoo",
               "type": "url",
               "url": "http://snoopsnoo.com/"


### PR DESCRIPTION
In preparation for Google [sun-setting Google+](https://www.blog.google/technology/safety-security/project-strobe/) by August 2019.

Also, [googleplussearch.chromefans.org](http://googleplussearch.chromefans.org/) appears to no longer work, returning:

```
Unauthorized access to internal API. Please refer to https://support.google.com/customsearch/answer/4542055
```
