### PR TITLE
Add MailDB.io

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -146,6 +146,11 @@
               "name": "IntelTechniques Cellular Email Tool",
               "type": "url",
               "url": "https://inteltechniques.com/osint/cellperm.html"
+            },
+            {
+              "name": "MailDB",
+              "type": "url",
+              "url": "https://maildb.io/"
             }
           ],
           "name": "Email Search",


### PR DESCRIPTION
Add [MailDB.io](https://maildb.io/).

>    Discover all contacts for any company on the web
>    First name, last name, job title, and phone number included, automatically and free of charge

Requires API key.

Allows searching by name and/or domain.

Returns email addresses, and a list of sources (web pages), with date stamp, of when each email address was retrieved from the source.

Sometimes also returns other interesting info, like name and job title.
