### PR TITLE
IP loggers in IP Address

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1506,6 +1506,23 @@
           ],
           "name": "Network Analysis Tools",
           "type": "folder"
+        },
+        {
+          "children": [
+			{
+              "name": "Ki.tc",
+              "type": "url",
+              "url": "https://ki.tc"
+            },
+            {
+              "name": "Grabify",
+              "type": "url",
+              "url": "https://grabify.link"
+            }
+            
+          ],
+          "name": "IP Loggers",
+          "type": "folder"
         }
       ],
       "name": "IP Address",


### PR DESCRIPTION
Created a new entry 'IP Loggers' as a child of IP Address. 

Included 2 projects

1. Ki.tc, which includes several CLI sub-projects but the prominent one is the 'url shortener' which features IP logging and Browser Fingerprinting given a link. [CLI]

2. Grabify, which includes the ability to select the desired link domain from a comprehensive list. [Web-Based]