### PR TITLE
Update Skype Resolver link

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -2864,9 +2864,9 @@
               "url": "http://skypegrab.net/oldip.php"
             },
             {
-              "name": "Skype Resolver 2016",
+              "name": "Skype Resolver 2019",
               "type": "url",
-              "url": "http://skresolver.com/"
+              "url": "http://www.skypeipresolver.net/"
             }
           ],
           "name": "Skype",


### PR DESCRIPTION
skresolver.com is a parked domain

I haven't tested skypeipresolver.net; however it appears to be a suitable replacement.
