### PR TITLE
Username Search Engines: removed gaddr.me, added namecheckup.com

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -45,9 +45,9 @@
         "url": "http://checkusernames.com/"
       },
       {
-        "name": "Gaddr.me",
+        "name": "NameCheckup",
         "type": "url",
-        "url": "https://gaddr.me/"
+        "url": "https://namecheckup.com/"
       },
       {
         "name": "Instant Username Search",


### PR DESCRIPTION
Updated 'Username Search Engines'

- Removed not workin https://gaddr.me/
- Added https://namecheckup.com/