### PR TITLE
improvement: removed DNSdumpster from whois

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -320,11 +320,6 @@
         "url": "http://domainbigdata.com/"
       },
       {
-        "name": "DNS Dumpster",
-        "type": "url",
-        "url": "https://dnsdumpster.com/"
-      },
-      {
         "name": "Whoisology",
         "type": "url",
         "url": "https://whoisology.com/#advanced"


### PR DESCRIPTION
I could not find any whois infomation about domain on dnsdumpster (https://dnsdumpster.com/), so i suggest to remove it from whois lookup tools list.