### PR TITLE
improvement: removed domainhistory.net from whois

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -330,11 +330,6 @@
         "url": "https://whoisology.com/#advanced"
       },
       {
-        "name": "Domain History",
-        "type": "url",
-        "url": "http://www.domainhistory.net/"
-      },
-      {
         "name": "Whois ARIN",
         "type": "url",
         "url": "https://whois.arin.net/ui/advanced.jsp"


### PR DESCRIPTION
domainhistory.net seems to be inactive for a long time, so i suggest to remove it from domain whois lookup services list.

According to webarchive (http://web.archive.org/web/2018*/domainhistory.net) it haven't been seen from more then one year, so i think it is not site temporary unavailability problem. 