### PR TITLE
improvement: correct dnsstuff whois lookup tool link

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -342,7 +342,7 @@
       {
         "name": "DNSstuff",
         "type": "url",
-        "url": "http://www.dnsstuff.com/tools"
+        "url": "https://tools.dnsstuff.com/"
       },
       {
         "name": "Robtex",


### PR DESCRIPTION
Current link to DNSstuff is incorrect and send us to tools reviews page (https://www.dnsstuff.com/tools). I suggest to replace this link with link to https://tools.dnsstuff.com/ which is tools homepage.