### PR TITLE
fix: correct markmonitor whois lookup link

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -357,7 +357,7 @@
       {
         "name": "MarkMonitor Whois Search",
         "type": "url",
-        "url": "https://domains.markmonitor.com/whois/charlescawleysucks.com"
+        "url": "https://domains.markmonitor.com/whois/"
       },
       {
         "name": "easyWhois",

--- a/public/arf.json
+++ b/public/arf.json
@@ -357,7 +357,7 @@
       {
         "name": "MarkMonitor Whois Search",
         "type": "url",
-        "url": "https://www.markmonitor.com/cgi-bin/affsearch.cgi?"
+        "url": "https://domains.markmonitor.com/whois/charlescawleysucks.com"
       },
       {
         "name": "easyWhois",


### PR DESCRIPTION
Markmonitor whois lookup tool moved from https://www.markmonitor.com/cgi-bin/affsearch.cgi? to https://domains.markmonitor.com/whois/charlescawleysucks.com