### PR TITLE
improvement: replace Whoismind with Whois AMPed

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -375,9 +375,9 @@
         "url": "https://who.is/"
       },
       {
-        "name": "Whoismind",
+        "name": "Whois AMPed",
         "type": "url",
-        "url": "http://www.whoismind.com/"
+        "url": "https://whoisamped.com/"
       },
       {
         "name": "ViewDNS.info",


### PR DESCRIPTION
Whoismind (http://www.whoismind.com/) redirects to Whois AMPed (https://whoisamped.com/), so i suggest to replace the link and the service title.