### PR TITLE
improvement: removed Daily DNS Changes from domains whois tools list

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -385,11 +385,6 @@
         "url": "http://viewdns.info/"
       },
       {
-        "name": "Daily DNS Changes",
-        "type": "url",
-        "url": "http://www.dailychanges.com/"
-      },
-      {
         "name": "Domainsdb.info",
         "type": "url",
         "url": "https://domainsdb.info"


### PR DESCRIPTION
"Daily DNS Changes" service (http://www.dailychanges.com/) become a part of DomainTools service and have no any direct whois records search anymore.