### PR TITLE
improvement: removed Domainsdb.info from whois tools

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -390,11 +390,6 @@
         "url": "http://www.dailychanges.com/"
       },
       {
-        "name": "Domainsdb.info",
-        "type": "url",
-        "url": "https://domainsdb.info"
-      },
-      {
         "name": "IP2WHOIS",
         "type": "url",
         "url": "https://www.ip2whois.com"


### PR DESCRIPTION
Domainsdb.info (https://domainsdb.info/) does not provide any whois information. 

> Registered domains search checks the lists of registered domains for names containing particular words/phrases/numbers or symbols. Technically it's just a GUI interface for domains-index.com database containing more than 260M of registered domains and 1000+ TLDS including newGTLDs. It's free to use and could be helpful domains/marketing research tool.