### PR TITLE
improvement: removed duplicated CertDB and update URL

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -545,9 +545,9 @@
         "url": "https://www.certificate-transparency.org/known-logs"
       },
       {
-        "name": "CertDB",
+        "name": "Spyse",
         "type": "url",
-        "url": "https://certdb.com/"
+        "url": "https://spyse.com/search/certificate"
       },
       {
         "name": "Censys",
@@ -563,11 +563,6 @@
         "name": "certgraph (T)",
         "type": "url",
         "url": "https://github.com/lanrat/certgraph"
-      },
-      {
-        "name": "CertDB",
-        "type": "url",
-        "url": "https://certdb.com/"
       }],
       "name": "Certificate Search",
       "type": "folder"


### PR DESCRIPTION
1. Removed duplicated link to CertDB in the same section
2. Replaced CertDB with Spyse, since CertDB (https://certdb.com/) is now part of the Spyse service (https://spyse.com/search/certificate)