### PR TITLE
improvement: removed ipintel.io from ip geo list

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1215,11 +1215,6 @@
         "url": "https://db-ip.com/"
       },
       {
-        "name": "ipintel.io",
-        "type": "url",
-        "url": "https://ipintel.io/"
-      },
-      {
         "name": "IP Location Finder",
         "type": "url",
         "url": "https://www.iplocation.net/"


### PR DESCRIPTION
ipintel.io seems to be dead.

It has not been working since at least September 3:
![image](https://user-images.githubusercontent.com/3992998/70708515-5fe1aa00-1ce3-11ea-944f-bf49dbc0a4e3.png)
