### PR TITLE
Improvement/remove portmap

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1257,7 +1257,7 @@
       {
         "name": "Spyse",
         "type": "url",
-        "url": "https://spyse.com/"
+        "url": "https://spyse.com/search/ip"
       },
       {
         "name": "Shodan",

--- a/public/arf.json
+++ b/public/arf.json
@@ -1265,11 +1265,6 @@
         "url": "https://www.shodan.io/"
       },
       {
-        "name": "Portmap",
-        "type": "url",
-        "url": "https://portmap.com/"
-      },  
-      {
         "name": "Scans.io",
         "type": "url",
         "url": "https://scans.io/"


### PR DESCRIPTION
Portmap (https://portmap.com/) now is a part of the Spyse (https://spyse.com/search/ip)