### PR TITLE
Update arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -6497,6 +6497,11 @@
       "name": "Mr.Looquer IOC Feed - 1st Dual Stack Threat Feed",
       "type": "url",
       "url": "https://iocfeed.mrlooquer.com"
+    },
+    {
+      "name": "REScure Cyber Threat Intelligence Project",
+      "type": "url",
+      "url": "https://rescure.fruxlabs.com"
     }],
     "name": "Threat Intelligence",
     "type": "folder"


### PR DESCRIPTION
We have started a new malware threat feed (REScure) which is accessible at :

homepage : https://rescure.fruxlabs.com/
Feedpath : https://rescure.fruxlabs.com/rescure_blacklist.txt
Feedpath : https://rescure.fruxlabs.com/rescure_domain_blacklist.txt

The feed is curated form an inhouse threat intelligence solution and is updated at every 6 hours. A blogpost detailing about this is mentioned here :

https://www.theprohack.com/2018/09/rescure-cyber-threat-intelligence-feed.html

Currently limited to only malicious IPs and domains, we will enhance this by adding IoCs such as malware hashes, et al in future.

Thanks !