### PR TITLE
Adding CyberDetective CTF as a Training material

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -6948,6 +6948,11 @@
       "name": "Smart Questions",
       "type": "url",
       "url": "http://www.catb.org/esr/faqs/smart-questions.html"
+    },
+    {
+      "name": "CyberDetective CTF",
+      "type": "url",
+      "url": "https://ctf.cybersoc.wales/"
     }],
     "name": "Training",
     "type": "folder"


### PR DESCRIPTION
Cyber Detective CTF is an OSINT-focussed CTF created by the Cyber Security Society at Cardiff University.

The are 40 challenges across 3 streams: General Knowledge, Life Online and Evidence Investigation.