### PR TITLE
update(arf.json): Added Freenet Project

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -5419,6 +5419,11 @@
         "url": "https://www.torproject.org/download/download-easy.html.en"
       },
       {
+        "name": "Freenet Project (T)",
+        "type": "url",
+        "url": "https://freenetproject.org/pages/download.html"
+      },
+      {
         "name": "I2P Anonymous Network (T)",
         "type": "url",
         "url": "https://geti2p.net/en/"
@@ -6531,6 +6536,11 @@
           "name": "Tor Download (T)",
           "type": "url",
           "url": "https://www.torproject.org/download/download-easy.html.en"
+        },
+        {
+          "name": "Freenet Project (T)",
+          "type": "url",
+          "url": "https://freenetproject.org/pages/download.html"
         },
         {
           "name": "I2P Anonymous Network (T)",


### PR DESCRIPTION
Freenet is free software which lets you anonymously share files, browse and publish "freesites" (web sites accessible only through Freenet) and chat on forums, without fear of censorship. Freenet is decentralised to make it less vulnerable to attack, and if used in "darknet" mode, where users only connect to their friends, is very difficult to detect.