### PR TITLE
Update arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1283,6 +1283,11 @@
         "name": "Masscan (T)",
         "type": "url",
         "url": "https://github.com/robertdavidgraham/masscan"
+      },
+      {
+        "name": "GIP.SH (GET IP)",
+        "type": "url",
+        "url": "https://GIP.SH/"
       }],
       "name": "Host / Port Discovery",
       "type": "folder"


### PR DESCRIPTION
https://gip.sh/ - (GET IP) is a portal providing information regarding client's IP Address such as IP intelligence, threats, ASN details, geolocation in addition to speed test function.