### PR TITLE
Update URL for gitleaks (code search)

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -4436,7 +4436,7 @@
       {
         "name": "GitLeaks",
         "type": "url",
-        "url": "https://gitleaks.com/"
+        "url": "https://github.com/zricethezav/gitleaks"
       }],
       "name": "Code Search",
       "type": "folder"


### PR DESCRIPTION
URL for gitleaks: https://gitleaks.com is not valid, replace with https://github.com/zricethezav/gitleaks