### PR TITLE
Update arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1754,10 +1754,11 @@
           "url": "http://www.geosetter.de/en/"
         },
         {
-          "name": "gbimg.org",
-          "type": "url",
-          "url": "http://gbimg.org/"
-        }],
+          "name":"xeuledoc - Fetch metadata about any public Google document",
+          "type":"url",
+          "url":"https://github.com/Malfrats/xeuledoc"
+        }
+        ],
         "name": "Metadata",
         "type": "folder"
       },


### PR DESCRIPTION
added xeuledoc - a metadata extractor for public google docs
remove gbimg.org - points to a dead webpage