### PR TITLE
Update arf.json category from "IP Address" to "IP & MAC Address".

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1519,7 +1519,7 @@
       "name": "IP Loggers",
       "type": "folder"
     }],
-    "name": "IP Address",
+    "name": "IP & MAC Address",
     "type": "folder"
   },
   {


### PR DESCRIPTION
This category title right now does not indicate that some tools nested under it can be used based on a MAC address (i.e. WiGLE), so it would be useful to make the name more broad. Maybe "IP & MAC Address" is not the best fit, but it's the first thing that comes to mind. 