### PR TITLE
Added base64decode.org

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -5713,6 +5713,11 @@
     "children": [
     {
       "children": [
+        {
+          "name" : "Base64decode.org",
+          "type" : "url",
+          "url" : "https://base64decode.org/"
+        }
 
       ],
       "name": "Base64",


### PR DESCRIPTION
base64decode.org is probably the most used website to decode base64 encoded strings. I saw that base64 folder didn't have any websites so I think this would be a fine addition to it.