### PR TITLE
remove /index on snoop station URL

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -2824,7 +2824,7 @@
       {
         "name": "Snoop Station",
         "type": "url",
-        "url": "http://snoopstation.com/index.html"
+        "url": "http://snoopstation.com"
       },
       {
         "name": "Melissa Data - People Finder (R)",


### PR DESCRIPTION
/index caused a 404 error, https://snoopstation.com/ is the correct URL. I noticed this and wanted to fix it!