### PR TITLE
Remove GeoChirp

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -2449,11 +2449,6 @@
       {
         "children": [
         {
-          "name": "GeoChirp",
-          "type": "url",
-          "url": "http://www.geochirp.com/"
-        },
-        {
           "name": "GeoSocial Footprint",
           "type": "url",
           "url": "http://geosocialfootprint.com/"


### PR DESCRIPTION
GeoChirp (geochirp.com) under "Social Networks," "Twitter," "Location / Mapping" returns an otherwise blank website with the header "Website Disabled."