### PR TITLE
Add Criminal IP Search

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -513,6 +513,11 @@
         "name": "AnalyzeID",
         "type": "url",
         "url": "http://analyzeid.com/"
+      },
+      {
+        "name": "Criminal IP Search",
+        "type": "url",
+        "url": "https://www.criminalip.io/"
       }],
       "name": "Discovery",
       "type": "folder"


### PR DESCRIPTION
Criminal IP Search is similar to services like Shadan and Censys,
it offers exploits、CVE detection and searching,
and easy-to-use searching filter,
also have an awesome detailed Historical Information