### PR TITLE
SWITCH Internet Domains whois lookup 

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -304,7 +304,8 @@
         "type": "url",
         "url": "http://whois.domaintools.com/"
       },
-         "name": "DomainTools Whois (.ch)",
+      {
+        "name": "DomainTools Whois (.ch)",
         "type": "url",
         "url": "https://www.nic.ch/whois/"
       },

--- a/public/arf.json
+++ b/public/arf.json
@@ -304,6 +304,10 @@
         "type": "url",
         "url": "http://whois.domaintools.com/"
       },
+         "name": "DomainTools Whois (.ch)",
+        "type": "url",
+        "url": "https://www.nic.ch/whois/"
+      },
       {
         "name": "Domain Big Data",
         "type": "url",

--- a/public/arf.json
+++ b/public/arf.json
@@ -305,7 +305,7 @@
         "url": "http://whois.domaintools.com/"
       },
       {
-        "name": "DomainTools Whois (.ch)",
+        "name": "SWITCH Internet Domains Whois (.ch)",
         "type": "url",
         "url": "https://www.nic.ch/whois/"
       },


### PR DESCRIPTION
requesting whois for .ch domains is not authorized unless from nic.ch, this can be reproduced by trying to whois ANY .ch domain. Due to this  I added nic.ch to the OSINTframework.