### PR TITLE
Add MetaDefender to Malicious File Analysis

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -6106,6 +6106,11 @@
         "url": "https://www.malwareviz.com/"
       },
       {
+        "name": "MetaDefender",
+        "type": "url",
+        "url": "https://metadefender.opswat.com/"
+      },
+      {
         "name": "Ether",
         "type": "url",
         "url": "http://ether.gtisc.gatech.edu/web_unpack"


### PR DESCRIPTION
Add OPSWAT's MetaDefender Cloud to the Hosted Automated Analysis section under the Malicious File Analysis section.