### PR TITLE
Remove Pastebin Trends

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -2034,11 +2034,6 @@
       {
         "children": [
         {
-          "name": "Pastebin Trends",
-          "type": "url",
-          "url": "http://pastebin.com/trends"
-        },
-        {
           "name": "Pastebin Alerts",
           "type": "url",
           "url": "http://andrewmohawk.com/pasteLert/"


### PR DESCRIPTION
Remove Pastebin Trends, the URL http://pastebin.com/trends does no longer work. 