### PR TITLE
Add Mojeek to General Search Engines

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -4332,6 +4332,11 @@
         "name": "Hulbee",
         "type": "url",
         "url": "https://hulbee.com/"
+      },
+      {
+        "name": "Mojeek",
+        "type": "url",
+        "url": "https://mojeek.com/"
       }],
       "name": "General Search",
       "type": "folder"


### PR DESCRIPTION
Add Mojeek, independent search engine, to the General Search Engines category.