### PR TITLE
deleted Namechk(T) as deprecated

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -10,11 +10,6 @@
         "url": "https://namechk.com/"
       },
       {
-        "name": "Namechk (T)",
-        "type": "url",
-        "url": "https://github.com/HA71/Namechk"
-      },
-      {
         "name": "KnowEm",
         "type": "url",
         "url": "http://knowem.com/"


### PR DESCRIPTION
Namechk (T) has not been updated for 4 years and the [github page](https://github.com/HA71/Namechk) says the tool does not work properly. 

I might create another PR if this gets merged for adding [Sherlock](https://github.com/sherlock-project/sherlock)