### PR TITLE
feat: add noscript tag

### DIFF
--- a/public/css/arf.css
+++ b/public/css/arf.css
@@ -4,6 +4,19 @@ body {
   font-family: "Helvetica Neue", Helvetica;
 }
 
+noscript p{
+  text-align: center;
+  background-color: rgb(255, 228, 196);
+  margin: 0 auto;
+  width: 80vw;
+  padding: 25px 0;
+  margin-top: 80px;
+  border-radius: 10px;
+  border: 1px solid rgb(255, 204, 153);
+  margin-bottom: 20px;
+  display: flex-wrap;
+}
+
 #body {
   margin: 0 auto;
   position: relative;

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,10 @@
     <script type="text/javascript" src="js/d3.v3.min.js"></script>
     <title>OSINT Framework</title>
   </head>
-
+  <noscript>
+    <p>Sorry, Your browser does not support JavaScript! Activate JavaScript on your browser or look for a compatible
+      browser to use the site.</p>
+  </noscript>
   <body>
     <div id="body">
       <div id="header">


### PR DESCRIPTION
Accessing the website I looked that if someone access it with JavaScript disabled, they just couldn't see the list.

So I implemented the `<noscript>` tag, a tag that defines an alternate content to be displayed to users that have disabled scripts in their browser or have a browser that doesn't support script. It looked like this:
![](https://i.imgur.com/spcDHof.png)