### PR TITLE
added the web-hosted version of whatsmyname

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -35,6 +35,11 @@
         "url": "https://github.com/WebBreacher/WhatsMyName"
       },
       {
+        "name": "WhatsMyName",
+        "type": "url",
+        "url": "https://whatsmyname.app/"
+      },
+      {
         "name": "Thats Them",
         "type": "url",
         "url": "https://thatsthem.com/"


### PR DESCRIPTION
did not remove the tool, as there is benefit in having both alternatives