### PR TITLE
FEAT: Add Apk Online under Mobile Emulation

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -5239,7 +5239,12 @@
           "name": "Nox App Player",
           "type": "url",
           "url": "https://www.bignox.com/"
-        }],
+        },
+        {
+          "name": "Apk Online",
+          "type": "url",
+          "url": "https://www.apkonline.net/"
+          }],
         "name": "Emulation Tools",
         "type": "folder"
       },


### PR DESCRIPTION
This commit adds "Apk Online" under Mobile Emulation > Android > Emulation Tools.

Apk Online is a free online Android emulation, where you can upload the APK file of the app you are going to test.
Just upload the APK and that will be installed automatically.
That is like Genymotion, except that is online.