### PR TITLE
Remove maildb.io

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -140,11 +140,6 @@
         "url": "https://github.com/m4ll0k/infoga"
       },
       {
-        "name": "MailDB",
-        "type": "url",
-        "url": "https://maildb.io/"
-      },
-      {
         "name": "Skymem",
         "type": "url",
         "url": "http://www.skymem.info/"


### PR DESCRIPTION
Reverting #123 because maildb.io now leads to a broken link.