### PR TITLE
Add Celuzador arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -3268,6 +3268,11 @@
       "name": "Numspy-Api",
       "type": "url",
       "url": "https://numspy.pythonanywhere.com/"
+    },
+    {
+      "name": "Celuzador",
+      "type": "url",
+      "url": "https://celuzador.online/"
     }],
     "name": "Telephone Numbers",
     "type": "folder"


### PR DESCRIPTION
Celuzador.online is added, which is a Chilean platform that aims to search through scraping Chilean sites for information about a phone number showing the name of the possible owner and if they have WhatsApp, the profile photo and the status with the date