### PR TITLE
Add Predicta Search in the "Email Search" folder

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -153,6 +153,11 @@
         "name": "MailsHunt",
         "type": "url",
         "url": "https://mailshunt.com/"
+      },
+      {
+        "name": "Predicta Search",
+        "type": "url",
+        "url": "https://predictasearch.com/"
       }],
       "name": "Email Search",
       "type": "folder"


### PR DESCRIPTION
This simple PR adds the new email reverse search engine predictasearch.com in the "Email Search" folder