### PR TITLE
Include namesdir.com url in Username Search Engines folder

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -53,6 +53,11 @@
         "name": "Instant Username Search",
         "type": "url",
         "url": "https://instantusername.com/"
+      },
+      {
+        "name": "Names Directory",
+        "type": "url",
+        "url": "https://namesdir.com/"
       }],
       "name": "Username Search Engines",
       "type": "folder"


### PR DESCRIPTION
See the following 2 points for how namesdir.com can help when doing OSINT:

-- Given a name (first name or last name), namesdir can help suggest usernames that someone with that name could likely use. So if you have been able to OSINT a name to a platform, namesdir can provide good username suggestions. To see these username suggestions, go to namesdir.com, search for a name, click on the name and scroll down to "Typos & Misspells"

-- Imagine this, you're on an OSINT hunt, you need to determine the full name of your OSINT target person, you come across an image with a name. You have a good hunch that this is the name of your target person. However, the image is blurred out or some characters of the name in the image are unreadable. You notice you are only able to read the first name perfectly as Jake. The last name has 10 characters and you can only read 3 (Mag) out of the image. In this case, namesdir.com can help you determine a good guess of the remaining 7 characters of the last name. Go to namesdir.com, search for Jake, select "Jake given name" and just Ctrl F the results for "Jake Mag". Quickly, you realize there is a last name called Magallanes making you figure out the full name of your target person as Jake Magallanes.