### PR TITLE
fix: missing comma after array element

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -4190,7 +4190,7 @@
       "name": "OpenInfrastructureMap",
       "type": "url",
       "url": "openinframap.org/"
-    }
+    },
     {
       "name": "OpenStreetMap Routing Service",
       "type": "url",


### PR DESCRIPTION
A missing comma after an array element caused error while parsing JSON.

![image](https://github.com/lockfale/OSINT-Framework/assets/48588762/2f33dd55-27a3-48b3-bb5f-8079294dbff5)

Problematic code:
_Missing comma at line 4193_
https://github.com/lockfale/OSINT-Framework/blob/80a6eb037f98ccc549ee595c62ea1b214180bf38/public/arf.json#L4189-L4195