### PR TITLE
Update arf.json - Deleted Not-Found Page

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -160,11 +160,6 @@
     {
       "children": [
       {
-        "name": "Corporatate Email Formats",
-        "type": "url",
-        "url": "https://sites.google.com/site/emails4corporations/home"
-      },
-      {
         "name": "Email Format",
         "type": "url",
         "url": "https://www.email-format.com/"


### PR DESCRIPTION
I deleted Corporate Email Formats from OSINT Framework > Email Address > Common Email Formats > Corporate Email Formats. This website returned a 404 error - Page Not Found