### PR TITLE
Add Bright Data Resource

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -2658,6 +2658,11 @@
     {
       "children": [
       {
+        "name": "Bright Data | SERP API (R)",
+        "type": "url",
+        "url": "https://brightdata.com/products/datasets/for-journalists"
+      },
+      {
         "name": "Social Searcher",
         "type": "url",
         "url": "http://www.social-searcher.com/"
@@ -5835,6 +5840,11 @@
       "type": "folder"
     },
     {
+      "name": "Bright Data | Datasets & Scraping (R)",
+      "type": "url",
+      "url": "https://brightdata.com/products/datasets/for-journalists"
+    },
+    {
       "name": "Paterva / Maltego (T)",
       "type": "url",
       "url": "https://www.maltego.com/"
@@ -6546,6 +6556,11 @@
         }],
         "name": "Proxy Tests",
         "type": "folder"
+      },
+      {
+        "name": "Bright Data | Proxies (R)",
+        "type": "url",
+        "url": "https://brightdata.com/products/datasets/for-journalists"
       },
       {
         "name": "NoScript (T)",


### PR DESCRIPTION
Bright Data offers a robust proxy network paired with web-scrapers and pre-built public datasets.

Services are 100% free for journalists and non-profit organizations looking to access public web-data.