### PR TITLE
Add Analyst Research Tools in the "OSINT Automation" folder 

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -5830,7 +5830,15 @@
 	"name": "IntelligenceX",
 	"type": "url",
 	"url": "https://intelx.io/"
+	      
+      },
+
+      {
+        "name": "Analyst Research Tools",
+        "type": "url",
+        "url": "https://analystresearchtools.com"
       }],
+	    
       "name": "OSINT Automation",
       "type": "folder"
     },

--- a/public/arf.json
+++ b/public/arf.json
@@ -5830,15 +5830,12 @@
 	"name": "IntelligenceX",
 	"type": "url",
 	"url": "https://intelx.io/"
-	      
       },
-
       {
         "name": "Analyst Research Tools",
         "type": "url",
         "url": "https://analystresearchtools.com"
       }],
-	    
       "name": "OSINT Automation",
       "type": "folder"
     },


### PR DESCRIPTION
This simple PR adds Analyst Research Tools, analystresearchtools.com in the "OSINT Automation" folder