### PR TITLE
Removed Waatp.com - Currently redirects to malware or dead site.

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -2891,11 +2891,6 @@
         "url": "http://infospace.com/"
       },
       {
-        "name": "Waatp",
-        "type": "url",
-        "url": "http://waatp.com/"
-      },
-      {
         "name": "Webmii",
         "type": "url",
         "url": "http://webmii.com/"


### PR DESCRIPTION
Waatp now redirects to dead site if lucky, malware if not. Simply removed this from the list to prevent others from clicking and reaching a broken site.

