### PR TITLE
Add "Epieos" to "Email Search" folder

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -159,6 +159,11 @@
         "name": "MailsHunt",
         "type": "url",
         "url": "https://mailshunt.com/"
+      },
+      {
+	"name": "Epieos",
+	"type": "url",
+	"url": "https://epieos.com/"
       }]
     },
     {


### PR DESCRIPTION
this pr adds https://epieos.com/ to Email Search folder.