### PR TITLE
Removing Facebook analytics items as both are defunct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # OSINT Framework
 
+**THIS IS A Fork of the original OSINT-Framework repository, being used for adding/editing items and then generating pull requests back into the original repo.**
 http://osintframework.com
 
 ## Notes

--- a/public/arf.json
+++ b/public/arf.json
@@ -5414,7 +5414,7 @@
     {
       "name": "Tor2web",
       "type": "url",
-      "url": "https://tor2web.org/"
+      "url": "https://www.tor2web.org/"
     },
     {
       "name": "Web O Proxy",

--- a/public/arf.json
+++ b/public/arf.json
@@ -2224,22 +2224,7 @@
           "type": "url",
           "url": "https://www.facebook.com/livemap#"
         }]
-      },
-      {
-        "name": "Analytics",
-        "type": "folder",
-        "children": [
-        {
-          "name": "fb-sleep-stats (T)",
-          "type": "url",
-          "url": "https://github.com/sqren/fb-sleep-stats"
-        },
-        {
-          "name": "Facebook Scanner",
-          "type": "url",
-          "url": "http://stalkscan.com/en/"
-        }]
-      }]
+      },]
     },
     {
       "name": "Instagram",


### PR DESCRIPTION
After attempting to use both tools removed in this change, I found them to be defunct