### PR TITLE
Adding ScamDB to Threat Intelligence 

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -6425,7 +6425,7 @@
     {
       "name": "Scam Database",
       "type": "url",
-      "url": "https://www.scamdb.net/"
+      "url": "https://www.scamdb.net"
     },
     {
       "name": "Bot Scout",

--- a/public/arf.json
+++ b/public/arf.json
@@ -6423,6 +6423,11 @@
       "url": "https://github.com/csirtgadgets/massive-octo-spice"
     },
     {
+      "name": "Scam Database",
+      "type": "url",
+      "url": "https://www.scamdb.net/"
+    },
+    {
       "name": "Bot Scout",
       "type": "url",
       "url": "http://botscout.com/"


### PR DESCRIPTION
Scam Database is a platform dedicated for reporting and sharing experiences of online fraud and scams. This is useful for OSINT searches on usernames, domains, email addresses etc.

https://www.scamdb.net/