### PR TITLE
Fix Tor2Web URL

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -5429,7 +5429,7 @@
     {
       "name": "Tor2web",
       "type": "url",
-      "url": "https://tor2web.org/"
+      "url": "https://www.tor2web.org/"
     },
     {
       "name": "Web O Proxy",


### PR DESCRIPTION
https://tor2web.org/ was not working
https://www.tor2web.org/ does work