### PR TITLE
Remove Compromised URL from Email Search

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -154,11 +154,6 @@
         "name": "Skymem",
         "type": "url",
         "url": "http://www.skymem.info/"
-      },
-      {
-        "name": "MailsHunt",
-        "type": "url",
-        "url": "https://mailshunt.com/"
       }]
     },
     {


### PR DESCRIPTION
Mailshunt.com has been compromised and now redirects users to various scam sites that prompt them to call a fake support number. Attached is a screenshot of one such redirect.
<img width="1678" alt="Screenshot 2025-02-14 at 11 19 53 AM" src="https://github.com/user-attachments/assets/cdf2a1f1-82d7-43c1-ae70-cb738cd17ccd" />
