### PR TITLE
Update arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -6370,7 +6370,7 @@
       {
         "name": "Faker.js",
         "type": "url",
-        "url": "https://cdn.rawgit.com/Marak/faker.js/master/examples/browser/index.html"
+        "url": "https://cdn.jsdelivr.net/npm/@faker-js/faker@10.0.0/dist/index.min.js"
       }]
     },
     {


### PR DESCRIPTION
Hey folks,
Noticed something under OpSec → Persona Creation → Faker.js — the link currently shows:

`Failed to fetch version info for Marak/faker.js`

Might be worth updating it to the new package link:
👉 https://cdn.jsdelivr.net/npm/@faker-js/faker@10.0.0/dist/index.min.js