### PR TITLE
Add OpenCelliD and beaconDB URLs

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -3894,6 +3894,16 @@
         "name": "AntennaSearch",
         "type": "url",
         "url": "http://www.antennasearch.com/"
+      },
+      {
+        "name": "OpenCelliD",
+        "type": "url",
+        "url": "https://opencellid.org/"
+      },
+      {
+        "name": "beaconDB",
+        "type": "url",
+        "url": "https://beacondb.net/"
       }]
     },
     {


### PR DESCRIPTION
Add two URLs to services that provide cell-based geolocation data.