### PR TITLE
Add Surfface.com to arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1639,6 +1639,11 @@
           "type": "url",
           "url": "http://images.yahoo.com/"
         },
+		{
+          "name": "Surfface Face & People Search Engine",
+          "type": "url",
+          "url": "https://surfface.com/"
+        },
         {
           "name": "TinEye Reverse Image Search",
           "type": "url",


### PR DESCRIPTION
Hope you are doing well. I would like to suggest adding our tool, Surfface.com, to your OSINT directory.

Surfface is a face search engine and people finder that, unlike Pimeyes or Lenso, also indexes social profiles. Our users can discover social accounts and faces that appear in public posts and clips on social media such as TikTok and Instagram, as well as many other online resources. In production we currently index over 100 million social profiles and more than 10 billion images, and our coverage is continuously expanding in both scale and functionality. Under the hood we also leverage Google, Yandex and other services to enhance discovery.

We are primarily focused on the US market, although access to our service is restricted in IL, TX, WA and a range of countries due to compliance and risks considerations.

Thanks for considering Surfface as a resource for your OSINT community, Stan