### PR TITLE
Remove World Aeronautical Database from arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -3726,11 +3726,6 @@
         "url": "https://www.flightradar24.com/"
       },
       {
-        "name": "World Aeronautical Database",
-        "type": "url",
-        "url": "http://worldaerodata.com/"
-      },
-      {
         "name": "ADS-B Exchange",
         "type": "url",
         "url": "https://www.adsbexchange.com/"


### PR DESCRIPTION
Removed World Aeronautical Database entry from JSON.

The site has been hacked and it is not secure:

Avast Antivirus discovered a threat
Category of threat Script:SNH-Gen [Trj]

<img width="706" height="302" alt="image" src="https://github.com/user-attachments/assets/dc8bf30c-bfd9-48bc-a410-2fd208dc496e" />
