### PR TITLE
Remove 0day.today which is now a trash casino page

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -6134,11 +6134,6 @@
       "url": "https://www.owasp.org/index.php/Main_Page"
     },
     {
-      "name": "0day.today",
-      "type": "url",
-      "url": "http://0day.today/"
-    },
-    {
       "name": "Secunia",
       "type": "url",
       "url": "https://secuniaresearch.flexerasoftware.com/community/research/"


### PR DESCRIPTION
In Exploits and Advisories, the link to 0day.today now points to a trash landing page with "best casinos".

Not useable anymore.