### PR TITLE
Add maritime osint tool

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -3774,6 +3774,11 @@
         "name": "Vessel Finder",
         "type": "url",
         "url": "https://www.vesselfinder.com/"
+      },
+      {
+        "name":"Global Fishing Watch vessel Tracking",
+        "type":"url",
+        "url":"https://globalfishingwatch.org"
       }]
     },
     {

--- a/public/arf.json
+++ b/public/arf.json
@@ -3776,7 +3776,7 @@
         "url": "https://www.vesselfinder.com/"
       },
       {
-        "name":"Global Fishing Watch vessel Tracking",
+        "name":"Global Fishing Watch Vessel Tracking",
         "type":"url",
         "url":"https://globalfishingwatch.org"
       }]


### PR DESCRIPTION
Added Global Fishing Watch as a maritime vessel tracking OSINT resource under Marine Records. 
Verified the link is free, publicly accessible, and not duplicated in arf.json.

