### PR TITLE
Add wayparam URL to Search Tools

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -4491,6 +4491,11 @@
       "type": "folder",
       "children": [
       {
+        "name": "wayparam",
+        "type": "url",
+        "url": "https://github.com/aleff-github/wayparam"
+      },
+	  {
         "name": "Million Short",
         "type": "url",
         "url": "https://millionshort.com/"


### PR DESCRIPTION
I’m releasing wayparam, a cross-platform Python CLI inspired by ParamSpider. It fetches historical URLs from the Wayback CDX API, filters “boring” static assets, and outputs normalized parameterized URLs (with masked values) in txt or JSONL. It’s pipeline-friendly (stdout clean, diagnostics on stderr), includes a man page, and ships with offline httpx-level integration tests (MockTransport).