### PR TITLE
Add Epstein Exposed - public interest case file database

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -3229,6 +3229,11 @@
         "name": "Federal Inmate Locator",
         "type": "url",
         "url": "https://www.bop.gov/inmateloc/"
+      },
+      {
+        "name": "Epstein Exposed",
+        "type": "url",
+        "url": "https://epsteinexposed.com"
       }]
     },
     {


### PR DESCRIPTION
Epstein Exposed (https://epsteinexposed.com) is a comprehensive, searchable public interest database of the Jeffrey Epstein case files released by the DOJ under H.R.4405. Features include:

- 2,145,445+ searchable DOJ documents with OCR text
- 1,723 person profiles with auto-linked document references
- Flight log browser (1,708 flights)
- Interactive network graph visualization
- Document integrity verification (SHA-256 hash checking)
- Full-text + semantic search across all documents
- Public REST API with 27 endpoints

Built with Next.js, open to researchers, journalists, and the public.