### PR TITLE
Add Epstein Exposed — DOJ case file database

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -3229,6 +3229,11 @@
         "name": "Federal Inmate Locator",
         "type": "url",
         "url": "https://www.bop.gov/inmateloc/"
+      },
+      {
+        "name": "Epstein Exposed",
+        "type": "url",
+        "url": "https://epsteinexposed.com"
       }]
     },
     {


### PR DESCRIPTION
## Summary

Adds [Epstein Exposed](https://epsteinexposed.com) to **Public Records → Court / Criminal Records**.

Epstein Exposed is a comprehensive, searchable database of 2M+ DOJ documents released under the Epstein Files Transparency Act (H.R.4405). Features include:

- **Full-text search** across 2M+ documents with OCR text
- **Network visualization** graph of persons, flights, and connections
- **Document integrity verification** with SHA-256 hash checking
- **Public REST API** (v2) with OpenAPI spec
- **No paywall, no login required** — fully open public interest resource

## Changes

- `public/arf.json`: Added one entry to "Court / Criminal Records" children array (5 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)