### PR TITLE
Add FootprintIQ URL to arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -66,7 +66,7 @@
         "url": "https://www.idcrawl.com/username"
       },
 	  {
-        "name": "FootprintIQ (T)",
+        "name": "FootprintIQ Username Search",
         "type": "url",
         "url": "https://footprintiq.app"
       },


### PR DESCRIPTION
FootprintIQ is an OSINT tool for analyzing username reuse and digital footprint exposure across online platforms.