### PR TITLE
Add WDES - Web Data Exposure Scanner to Vulnerabilities/Scanners

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1178,6 +1178,11 @@
           "name": "Online Nikto scanner",
           "type": "url",
           "url": "https://nikto.online/"
+        },
+		{
+          "name": "WDES - Web Data Exposure Scanner (T)",
+          "type": "url",
+          "url": "https://github.com/eduardoit/web-data-exposure-scanner"
         }]
       },
       {


### PR DESCRIPTION
WDES (Web Data Exposure Scanner) is an open-source OSINT tool for proactively detecting sensitive data exposed on websites, such as corporate emails, ID numbers, phone numbers, and internal files. Built in Python, it runs locally from the command line with no external dependencies. Placed under Domain Name → Vulnerabilities → Scanners.
GitHub: https://github.com/eduardoit/web-data-exposure-scanner