### PR TITLE
Add Lullar — free username/email search tool (149+ platforms)

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -74,6 +74,11 @@
         "name": "Names Directory",
         "type": "url",
         "url": "https://namesdir.com/"
+      },
+      {
+        "name": "Lullar",
+        "type": "url",
+        "url": "https://com.lullar.com"
       }]
     },
     {


### PR DESCRIPTION
## Summary

- Adds [Lullar](https://com.lullar.com) to the **Username > Username Search Engines** section in `public/arf.json`
- Lullar is a free web-based tool that searches usernames and emails across 149+ platforms (social media, forums, gaming, developer sites)
- No signup required

## Disclosure

This is a self-promotional submission. I am the maintainer of Lullar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)