### PR TITLE
Fix D3 tree not rendering: remove null entry in arf.json

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -57,7 +57,6 @@
             }
           ]
         },
-        null,
         {
           "name": "Specific Sites",
           "type": "folder",

--- a/public/js/arf.js
+++ b/public/js/arf.js
@@ -19,7 +19,9 @@ var vis = d3.select("#body").append("svg")
     .attr("transform", "translate(" + margin[3] + "," + margin[0] + ")");
 
 d3.json("arf.json").then(function(json) {
-  root = d3.hierarchy(json);
+  root = d3.hierarchy(json, function(d) {
+    return d && d.children ? d.children.filter(function(c) { return c != null; }) : null;
+  });
   root.x0 = height / 2;
   root.y0 = 0;
 


### PR DESCRIPTION
d3.hierarchy() in D3 v7 does not tolerate null entries in children arrays (v3 was lenient). A null element at Username.children[1] caused the entire tree to fail silently.

- Remove the null entry from arf.json
- Add a defensive children filter in d3.hierarchy() call so future null entries degrade gracefully instead of breaking the tree