### PR TITLE
Add wrangler.jsonc for Cloudflare static asset deployment

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "osint-framework",
+  "compatibility_date": "2026-03-23",
+  "assets": {
+    "directory": "./public"
+  }
+}


### PR DESCRIPTION
Cloudflare deploy fails with "Missing entry-point to Worker script or to assets directory" because there is no wrangler config telling it where the static files live. This points it at ./public.