### PR TITLE
Add vehicle OSINT tools, remove paid-only Berla entry

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -3409,9 +3409,39 @@
               "url": "https://vpic.nhtsa.dot.gov/api/"
             },
             {
-              "name": "Berla Vehicle Lookup (R$)",
+              "name": "FindByPlate",
               "type": "url",
-              "url": "https://berla.co/vehicle_lookup/"
+              "url": "https://findbyplate.com/"
+            },
+            {
+              "name": "carVertical VIN Decoder",
+              "type": "url",
+              "url": "https://www.carvertical.com/vin-decoder"
+            },
+            {
+              "name": "autoDNA VIN Lookup",
+              "type": "url",
+              "url": "https://www.autodna.com/"
+            },
+            {
+              "name": "VinDecodr",
+              "type": "url",
+              "url": "https://vindecodr.com/"
+            },
+            {
+              "name": "AutoRef (EU)",
+              "type": "url",
+              "url": "https://www.autoref.eu/en"
+            },
+            {
+              "name": "Carnet.ai",
+              "type": "url",
+              "url": "https://carnet.ai/"
+            },
+            {
+              "name": "Finnik (NL)",
+              "type": "url",
+              "url": "https://finnik.nl/en"
             }
           ]
         },


### PR DESCRIPTION
Adds 7 new free/freemium vehicle lookup tools to Transportation > Vehicle Records: FindByPlate, carVertical VIN Decoder, autoDNA, VinDecodr, AutoRef (EU), Carnet.ai, and Finnik (NL). Removes Berla Vehicle Lookup which is a paid-only tool incompatible with the framework's free/freemium policy.

Refs: THE-24, THE-29