### PR TITLE
fix(ci): remove --exclude-mail flag removed in lychee v0.23.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
             --timeout 20
             --max-retries 2
             --retry-wait-time 5
-            --exclude-mail
             --accept 200,201,204,206,301,302,307,308,403,429
             urls.txt
           fail: true


### PR DESCRIPTION
lychee v0.23.0 dropped --exclude-mail; mail links are now excluded by default. Keeping the flag causes exit code 2 and breaks every CI run.

Fixes THE-85.