### PR TITLE
Remove obsolete phone lookup tools and validate Annual Reports HTTPS (THE-86)

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -2950,19 +2950,9 @@
           "url": "https://whocalld.com/"
         },
         {
-          "name": "411",
-          "type": "url",
-          "url": "https://www.411.com/reverse-phone-lookup"
-        },
-        {
           "name": "CallerID Test",
           "type": "url",
           "url": "https://calleridtest.com/"
-        },
-        {
-          "name": "ThatsThem - Reverse Phone Lookup",
-          "type": "url",
-          "url": "https://thatsthem.com/reverse-phone-lookup"
         },
         {
           "name": "Twilio Lookup",


### PR DESCRIPTION
## Summary
- remove `411` from `Telephone Numbers`
- remove `ThatsThem - Reverse Phone Lookup` from `Telephone Numbers`
- verify `Business Records > Annual Reports` URLs already use HTTPS

## Issue mapping
- GitHub #415 requested removal of `411` and `ThatsThem` from phone lookup
- GitHub #425 requested HTTPS correction for annual report links; current `master` already uses HTTPS for those entries

## Validation
- JSON validated with `jq empty public/arf.json`
