### PR TITLE
Promote Cloud Infrastructure to top-level category (THE-60)

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -1019,32 +1019,6 @@
           ]
         },
         {
-          "name": "Cloud Resources",
-          "type": "folder",
-          "children": [
-            {
-              "name": "Public Buckets",
-              "type": "url",
-              "url": "https://buckets.grayhatwarfare.com/"
-            },
-            {
-              "name": "Online Port scanner",
-              "type": "url",
-              "url": "https://portscanner.online/"
-            },
-            {
-              "name": "CloudScraper (T)",
-              "type": "url",
-              "url": "https://github.com/jordanpotti/cloudscraper"
-            },
-            {
-              "name": "Check site availability Online",
-              "type": "url",
-              "url": "https://upcheck.online/"
-            }
-          ]
-        },
-        {
           "name": "Vulnerabilities",
           "type": "folder",
           "children": [
@@ -1136,6 +1110,157 @@
               "name": "Google",
               "type": "url",
               "url": "https://safebrowsing.google.com/safebrowsing/report_phish/?hl=en"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Cloud Infrastructure",
+      "type": "folder",
+      "children": [
+        {
+          "name": "AWS Enumeration",
+          "type": "folder",
+          "children": [
+            {
+              "name": "cloud_enum (T)",
+              "type": "url",
+              "url": "https://github.com/initstring/cloud_enum"
+            },
+            {
+              "name": "AWSBucketDump (T)",
+              "type": "url",
+              "url": "https://github.com/jordanpotti/AWSBucketDump"
+            },
+            {
+              "name": "Subfinder (T)",
+              "type": "url",
+              "url": "https://github.com/projectdiscovery/subfinder"
+            }
+          ]
+        },
+        {
+          "name": "Azure/GCP Discovery",
+          "type": "folder",
+          "children": [
+            {
+              "name": "GCPBucketBrute (T)",
+              "type": "url",
+              "url": "https://github.com/RhinoSecurityLabs/GCPBucketBrute"
+            },
+            {
+              "name": "AADInternals (T)",
+              "type": "url",
+              "url": "https://github.com/Gerenios/AADInternals"
+            },
+            {
+              "name": "ROADtools (T)",
+              "type": "url",
+              "url": "https://github.com/dirkjanm/roadtools"
+            },
+            {
+              "name": "MicroBurst (T)",
+              "type": "url",
+              "url": "https://github.com/NetSPI/MicroBurst"
+            },
+            {
+              "name": "Stormspotter (T)",
+              "type": "url",
+              "url": "https://github.com/Azure/Stormspotter"
+            }
+          ]
+        },
+        {
+          "name": "S3/Blob Storage",
+          "type": "folder",
+          "children": [
+            {
+              "name": "Public Buckets",
+              "type": "url",
+              "url": "https://buckets.grayhatwarfare.com/"
+            },
+            {
+              "name": "goblob (T)",
+              "type": "url",
+              "url": "https://github.com/Macmod/goblob"
+            },
+            {
+              "name": "S3Scanner (T)",
+              "type": "url",
+              "url": "https://github.com/sa7mon/s3scanner"
+            },
+            {
+              "name": "BucketLoot (T)",
+              "type": "url",
+              "url": "https://github.com/redhuntlabs/BucketLoot"
+            },
+            {
+              "name": "lazys3 (T)",
+              "type": "url",
+              "url": "https://github.com/nahamsec/lazys3"
+            }
+          ]
+        },
+        {
+          "name": "Cloud Configuration Analysis",
+          "type": "folder",
+          "children": [
+            {
+              "name": "Prowler (T)",
+              "type": "url",
+              "url": "https://github.com/prowler-cloud/prowler"
+            },
+            {
+              "name": "ScoutSuite (T)",
+              "type": "url",
+              "url": "https://github.com/nccgroup/ScoutSuite"
+            },
+            {
+              "name": "Cloud Custodian (T)",
+              "type": "url",
+              "url": "https://github.com/cloud-custodian/cloud-custodian"
+            },
+            {
+              "name": "Checkov (T)",
+              "type": "url",
+              "url": "https://github.com/bridgecrewio/checkov"
+            },
+            {
+              "name": "Steampipe (T)",
+              "type": "url",
+              "url": "https://github.com/turbot/steampipe"
+            }
+          ]
+        },
+        {
+          "name": "SaaS Footprinting",
+          "type": "folder",
+          "children": [
+            {
+              "name": "Amass (T)",
+              "type": "url",
+              "url": "https://github.com/owasp-amass/amass"
+            },
+            {
+              "name": "Sublist3r (T)",
+              "type": "url",
+              "url": "https://github.com/aboul3la/Sublist3r"
+            },
+            {
+              "name": "theHarvester (T)",
+              "type": "url",
+              "url": "https://github.com/laramies/theHarvester"
+            },
+            {
+              "name": "SpiderFoot (T)",
+              "type": "url",
+              "url": "https://github.com/smicallef/spiderfoot"
+            },
+            {
+              "name": "dnsrecon (T)",
+              "type": "url",
+              "url": "https://github.com/darkoperator/dnsrecon"
             }
           ]
         }
@@ -3331,12 +3456,12 @@
           "url": "https://www.brbpub.com/"
         },
         {
-          "name": "GOVDATA - Das Datenportal f\u00fcr Deutschland (German)",
+          "name": "GOVDATA - Das Datenportal für Deutschland (German)",
           "type": "url",
           "url": "https://www.govdata.de/"
         },
         {
-          "name": "Open-Data-Portal M\u00fcnchen (German)",
+          "name": "Open-Data-Portal München (German)",
           "type": "url",
           "url": "https://www.opengov-muenchen.de/"
         },
@@ -6726,7 +6851,7 @@
               "url": "https://themanyhats.club/centralised-place-for-privacy-resources/"
             },
             {
-              "name": "The Hitchhiker\u2019s Guide to Online Anonymity",
+              "name": "The Hitchhiker’s Guide to Online Anonymity",
               "type": "url",
               "url": "https://anonymousplanet.org/guide/"
             },


### PR DESCRIPTION
- Remove Cloud Resources subcategory from Domain Name
- Add Cloud Infrastructure as top-level category with 5 subcategories:
  - AWS Enumeration: cloud_enum, AWSBucketDump, Subfinder
  - Azure/GCP Discovery: GCPBucketBrute, AADInternals, ROADtools, MicroBurst, Stormspotter
  - S3/Blob Storage: Public Buckets (GrayhatWarfare), goblob, S3Scanner, BucketLoot, lazys3
  - Cloud Configuration Analysis: Prowler, ScoutSuite, Cloud Custodian, Checkov, Steampipe
  - SaaS Footprinting: Amass, Sublist3r, theHarvester, SpiderFoot, dnsrecon
- Migrated Public Buckets (GrayhatWarfare) from Domain Name > Cloud Resources
- Dropped CloudScraper (7yr stale), upcheck.online, portscanner.online (not cloud-specific)
- 23 total tools: 18 new additions + 1 migrated from Domain Name