### PR TITLE
Rename Forums/Blogs/IRC to Online Communities (THE-58)

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -4486,9 +4486,46 @@
       ]
     },
     {
-      "name": "Forums / Blogs / IRC",
+      "name": "Online Communities",
       "type": "folder",
       "children": [
+        {
+          "name": "Blog Search Engines",
+          "type": "folder",
+          "children": [
+            {
+              "name": "Live Journal Seek",
+              "type": "url",
+              "url": "https://ljseek.com/"
+            },
+            {
+              "name": "Blog Search Engine",
+              "type": "url",
+              "url": "https://www.blogsearchengine.org/"
+            }
+          ]
+        },
+        {
+          "name": "Discord Servers",
+          "type": "folder",
+          "children": [
+            {
+              "name": "Discord Bot List",
+              "type": "url",
+              "url": "https://discord.bots.gg/"
+            },
+            {
+              "name": "ReconXplorer (T)",
+              "type": "url",
+              "url": "https://github.com/root7am/ReconXplorer"
+            },
+            {
+              "name": "Top.gg",
+              "type": "url",
+              "url": "https://top.gg/"
+            }
+          ]
+        },
         {
           "name": "Forum Search Engines",
           "type": "folder",
@@ -4521,27 +4558,6 @@
           ]
         },
         {
-          "name": "Blog Search Engines",
-          "type": "folder",
-          "children": [
-            {
-              "name": "Live Journal Seek",
-              "type": "url",
-              "url": "https://ljseek.com/"
-            },
-            {
-              "name": "Topix",
-              "type": "url",
-              "url": "https://www.pch.com/quizzes"
-            },
-            {
-              "name": "Blog Search Engine",
-              "type": "url",
-              "url": "https://www.blogsearchengine.org/"
-            }
-          ]
-        },
-        {
           "name": "IRC Search",
           "type": "folder",
           "children": [
@@ -4559,6 +4575,27 @@
               "name": "netsplit.de",
               "type": "url",
               "url": "https://netsplit.de/channels/search.php"
+            }
+          ]
+        },
+        {
+          "name": "Reddit Communities",
+          "type": "folder",
+          "children": [
+            {
+              "name": "Arctic Shift",
+              "type": "url",
+              "url": "https://arctic-shift.photon-reddit.com/"
+            },
+            {
+              "name": "Cama's Reddit Search",
+              "type": "url",
+              "url": "https://camas.github.io/reddit-search/"
+            },
+            {
+              "name": "Reveddit",
+              "type": "url",
+              "url": "https://www.reveddit.com/"
             }
           ]
         }


### PR DESCRIPTION
## Summary

Renames the \`Forums / Blogs / IRC\` top-level category to \`Online Communities\` to better reflect 2026 platform reality, and adds two new subcategories for modern community platforms.

## Changes

**Renamed category:**
- \`Forums / Blogs / IRC\` → \`Online Communities\`

**Preserved existing subcategories:**
- Blog Search Engines (2 tools — removed dead Topix entry, site shut down 2018)
- Forum Search Engines (5 tools, unchanged)
- IRC Search (4 tools, unchanged)

**Added new subcategories:**
- Discord Servers (3 tools: Top.gg, Discord Bot List, ReconXplorer)
- Reddit Communities (3 tools: Arctic Shift, Cama's Reddit Search, Reveddit)

**Excluded (dedup rationale):**
- \`Telegram Groups / Channels\` — all tools already present in \`Instant Messaging > Telegram\`
- \`Dark Web Forums\` — Ahmia already in \`Dark Web > TOR Search\`; TorBot already in \`Dark Web > Discovery\`

## Test Plan

- [x] JSON validated clean
- [x] Confirmed no new duplicates introduced
- [x] Removed dead Topix URL (redirects to pch.com/quizzes)
- [ ] Board review of new subcategory placement