### PR TITLE
Add FootprintIQ to Username Search Engines (THE-214)

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -151,6 +151,26 @@
               "deprecated": false
             },
             {
+              "name": "FootprintIQ",
+              "type": "url",
+              "url": "https://footprintiq.app",
+              "description": "Ethical digital footprint scanner that searches usernames, emails, and phone numbers across 500+ platforms. Includes breach detection, data broker scanning, and confidence scoring to reduce false positives.",
+              "status": "live",
+              "pricing": "freemium",
+              "bestFor": "Username and email footprint scanning with breach and data broker exposure checks",
+              "input": "Username, email address, or phone number",
+              "output": "Matched profiles across 500+ platforms, breach exposure, data broker listings",
+              "opsec": "active",
+              "opsecNote": "Queries are routed through FootprintIQ infrastructure; target platforms may log lookup activity.",
+              "localInstall": false,
+              "googleDork": false,
+              "registration": false,
+              "editUrl": false,
+              "api": false,
+              "invitationOnly": false,
+              "deprecated": false
+            },
+            {
               "name": "GitFive (T)",
               "type": "url",
               "url": "https://github.com/mxrch/GitFive",


### PR DESCRIPTION
## Summary

Resolves the merge conflict in PR #639 by applying the community-contributed FootprintIQ tool addition against the current master branch with full enrichment metadata.

**What changed:**
- Added FootprintIQ to the Username Search Engines section of `arf.json`
- Populated all enrichment fields (description, status, pricing, bestFor, input/output, opsec profile, flags)
- Original contribution by @TheCandyMan-apps in #639; this PR supersedes that one since the fork-based PR cannot be rebased from our side

**About FootprintIQ:**
- Ethical digital footprint scanner — searches usernames, emails, and phone numbers across 500+ platforms
- Includes breach detection, data broker scanning, and confidence scoring (LENS) to reduce false positives
- Freemium pricing model, active OPSEC profile
- Site verified live at https://footprintiq.app

**Recommendation:** Close PR #639 with a thank-you comment when merging this one.