### PR TITLE
Add MERIDIAN to Geolocation Tools / Maps

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -4703,6 +4703,26 @@
               "api": false,
               "invitationOnly": false,
               "deprecated": false
+            },
+            {
+              "name": "MERIDIAN",
+              "type": "url",
+              "url": "https://meridianspectre.com",
+              "description": "Geospatial intelligence platform mapping over 1 million verified military facilities, ORBAT data, and threat assessments across 18 state and non-state adversary actors including Iran, Russia, North Korea, China, and Syria.",
+              "status": "live",
+              "pricing": "paid",
+              "bestFor": "Adversary military facility mapping and order-of-battle analysis",
+              "input": "Country, region, or facility category",
+              "output": "Mapped military facilities with metadata and threat context",
+              "opsec": "passive",
+              "opsecNote": "Subscription-based platform; standard web access.",
+              "localInstall": false,
+              "googleDork": false,
+              "registration": true,
+              "editUrl": false,
+              "api": false,
+              "invitationOnly": false,
+              "deprecated": false
             }
           ]
         },


### PR DESCRIPTION
Adding MERIDIAN to the Geolocation Tools / Maps category.

MERIDIAN is a geospatial OSINT platform that maps over 1 million verified military facilities across 18 state and non-state adversary actors, including Iran, Russia, North Korea, China, and Syria. It provides ORBAT data, threat assessments, and facility-level metadata for analysts, researchers, and journalists working in defense and security OSINT.

- Live and publicly accessible at https://meridianspectre.com
- Subscription-based access (registration required)
- Standard web platform; passive from an OPSEC perspective

Happy to adjust the entry, description, or category placement if needed.