### PR TITLE
Add YT2GDrive — multi-platform video downloader for OSINT researchers

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -6879,6 +6879,26 @@
                   "name": "yasiv-youtube",
                   "type": "url",
                   "url": "https://yasiv.com/youtube/"
+                },
+                {
+                  "name": "YT2GDrive (R)",
+                  "type": "url",
+                  "url": "https://photovideo.ae/download",
+                  "description": "Web-based video downloader supporting YouTube, TikTok, Instagram, Twitter/X, Facebook, and 1000+ sites. Allows direct saving of downloaded media to Google Drive for evidence archiving and media preservation.",
+                  "status": "live",
+                  "pricing": "free",
+                  "bestFor": "Media preservation and evidence archiving for journalists and OSINT researchers",
+                  "input": "Video URL from YouTube, TikTok, Instagram, Twitter/X, Facebook, or 1000+ supported sites",
+                  "output": "Downloaded video file saved to Google Drive or local storage",
+                  "opsec": "active",
+                  "opsecNote": "Requests are made to the target platform to fetch video content, which may expose investigator network identifiers.",
+                  "localInstall": false,
+                  "googleDork": false,
+                  "registration": true,
+                  "editUrl": false,
+                  "api": false,
+                  "invitationOnly": false,
+                  "deprecated": false
                 }
               ]
             }


### PR DESCRIPTION
## Summary

Adds **YT2GDrive** to `Images / Videos / Docs > Videos > Analyze / Record`.

**URL:** https://photovideo.ae/download

### What it does
- Downloads video from YouTube, TikTok, Instagram, Twitter/X, Facebook, and 1000+ sites (powered by yt-dlp)
- Saves directly to **Google Drive** for cloud evidence archiving — no local storage required
- Alternatively downloads straight to the user's device

### Why it fits OSINT researchers
- **Journalists & investigators** can archive video evidence directly to Google Drive without installing software
- **Documentary researchers** can collect source material from multiple platforms in one place
- No command-line knowledge needed — web UI with Google OAuth
- Google-verified OAuth integration (no third-party credential handling)
- Free, no account required for basic use; Google Drive save requires Google login
- Open-source backend (yt-dlp)

### Node placement
`Images / Videos / Docs > Videos > Analyze / Record` — after `yasiv-youtube`

### Checklist
- [x] Tool is live and publicly accessible
- [x] Free tier available
- [x] No local install required
- [x] Relevant to OSINT/media preservation use cases
- [x] JSON is valid (validated with Python json.load)
- [x] `(R)` marker added per convention (requires Google login for Drive save)