### PR TITLE
feat: add OpenOSINT — AI-powered OSINT agent and MCP server

### DIFF
--- a/public/arf.json
+++ b/public/arf.json
@@ -19369,6 +19369,26 @@
               "api": false,
               "invitationOnly": false,
               "deprecated": false
+            },
+            {
+              "name": "OpenOSINT (T)",
+              "type": "url",
+              "url": "https://github.com/OpenOSINT/OpenOSINT",
+              "description": "AI-powered OSINT agent, MCP server, and CLI. Exposes 9 intelligence-gathering tools to AI agents via the Model Context Protocol. Supports autonomous multi-step investigations from an interactive REPL, direct CLI usage, and integration with Claude Code and Claude Desktop.",
+              "status": "live",
+              "pricing": "free",
+              "bestFor": "Autonomous AI-driven OSINT investigations from the terminal",
+              "input": "Email address, username, domain, IP address, phone number",
+              "output": "Account enumeration, breach exposure, WHOIS data, geolocation, subdomains, Google dork URLs, Pastebin mentions, phone intelligence",
+              "opsec": "passive",
+              "opsecNote": "All lookups go through third-party APIs and binaries. No direct contact with the target. AI layer requires ANTHROPIC_API_KEY.",
+              "localInstall": true,
+              "googleDork": false,
+              "registration": false,
+              "editUrl": false,
+              "api": true,
+              "invitationOnly": false,
+              "deprecated": false
             }
           ]
         },


### PR DESCRIPTION
## What's being added

[OpenOSINT](https://github.com/OpenOSINT/OpenOSINT) — an AI-powered OSINT framework 
that exposes 9 intelligence-gathering tools to AI agents via the Model Context Protocol (MCP). 
It also works as a standalone CLI and interactive REPL.

**Tools included:** email enumeration, username search (300+ platforms), 
breach check (HIBP), WHOIS, IP intelligence, subdomain enumeration, 
Google dork generator, Pastebin search, phone intelligence.

**Interfaces:**
- Interactive AI REPL (Claude-powered autonomous investigations)
- Direct CLI for scripting
- MCP server for Claude Code and Claude Desktop

## Entry details

- Local install (T): `pip install openosint`
- Pricing: free
- Opsec: passive
- License: MIT
- Status: live

## Links

- GitHub: https://github.com/OpenOSINT/OpenOSINT
- Docs: https://openosint.tech